### PR TITLE
feat: add response headers to HttpResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An elegant fetch wrapper inspired by [`axios`](https://github.com/axios/axios) a
 - ✅ Designed to work well with [**TanStack Query**](https://github.com/TanStack/query)
 - ✅ Response validation with [**StandardSchema**](https://github.com/standard-schema/standard-schema) (Zod, Arktype, ...)  
 - ✅ Typed HTTP responses & error union (`HttpResult<T>`)
+- ✅ Response headers available in every `HttpResult<T>` (`result.headers`)
 - ✅ Built-in timeout and abort controller
 - ✅ Supports `FormData`, URL query (`?query`) and parameters (`/:id`)
 - ✅ Minimal plugin system (`onRequest`, `onResponse`) for modular extensions
@@ -35,7 +36,8 @@ if (!result.success) {
   return console.error(result.error.message);
 }
 
-console.log(result.data.name);
+const requestId = result.headers.get('x-request-id');
+console.log(result.data.name, requestId);
 ```
 
 ## Plugin System
@@ -123,6 +125,7 @@ function createRetryMessagePlugin(options: RetryMessagePluginOptions) {
       if (!result.success && result.error.type === 'timeout') {
         return {
           success: false,
+          headers: result.headers,
           error: {
             ...result.error,
             message: options.message,

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ An elegant fetch wrapper inspired by [`axios`](https://github.com/axios/axios) a
 - ✅ Typed HTTP responses & error union (`HttpResult<T>`)
 - ✅ Built-in timeout and abort controller
 - ✅ Supports `FormData`, URL query (`?query`) and parameters (`/:id`)
+- ✅ Minimal plugin system (`onRequest`, `onResponse`) for modular extensions
 
 #### Installation
 
-```apache
-λ bun add @zhaoworks/fetch
+```bash
+bun add @zhaoworks/fetch
 ```
 
-#### Usage
+## Usage
 
 ```ts
 import { HttpClient } from '@zhaoworks/fetch';
@@ -35,6 +36,106 @@ if (!result.success) {
 }
 
 console.log(result.data.name);
+```
+
+## Plugin System
+
+The plugin system is intentionally small and composable:
+
+- `onRequest(context)` runs before `fetch`
+- `onResponse(context)` runs after response parsing
+- Plugins run in the order they are provided
+- `onResponse` can return a new `HttpResult<T>` to transform/override output
+
+### Plugin API
+
+```ts
+import type {
+  HttpPlugin,
+  HttpRequestContext,
+  HttpResponseContext,
+  HttpResult,
+} from '@zhaoworks/fetch';
+```
+
+```ts
+export interface HttpPlugin {
+  name?: string;
+  onRequest?: <T>(context: HttpRequestContext<T>) => void | Promise<void>;
+  onResponse?: <T>(
+    context: HttpResponseContext<T>
+  ) => HttpResult<T> | void | Promise<HttpResult<T> | void>;
+}
+```
+
+### Example 1: Auth Header Plugin
+
+```ts
+import { HttpClient } from '@zhaoworks/fetch';
+
+const authPlugin = {
+  name: 'auth',
+  onRequest({ headers }) {
+    headers.set('Authorization', `Bearer ${getToken()}`);
+  },
+};
+
+const http = new HttpClient({
+  endpoint: 'https://api.example.com',
+  plugins: [authPlugin],
+});
+```
+
+### Example 2: Request Timing Plugin
+
+```ts
+const timingPlugin = {
+  name: 'timing',
+  onRequest(context) {
+    (context as any).startedAt = performance.now();
+  },
+  onResponse(context) {
+    const startedAt = (context.request as any).startedAt;
+    if (typeof startedAt === 'number') {
+      console.log(
+        `[fetch] ${context.request.method} ${context.request.url} took ${Math.round(performance.now() - startedAt)}ms`
+      );
+    }
+  },
+};
+```
+
+### Example 3: Normalize API Errors
+
+```ts
+const normalizeErrorPlugin = {
+  name: 'normalize-error',
+  onResponse({ result }) {
+    if (!result.success && result.error.type === 'response' && result.error.status === 401) {
+      return {
+        success: false,
+        error: {
+          ...result.error,
+          message: 'Your session has expired. Please sign in again.',
+        },
+      };
+    }
+  },
+};
+
+const http = new HttpClient({
+  endpoint: 'https://api.example.com',
+  plugins: [normalizeErrorPlugin],
+});
+```
+
+### Composition
+
+```ts
+const http = new HttpClient({
+  endpoint: 'https://api.example.com',
+  plugins: [authPlugin, timingPlugin, normalizeErrorPlugin],
+});
 ```
 
 ### License

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,11 +45,14 @@ interface RequestConfig<T> {
   params?: Record<string, string | number>;
 }
 
+export type HttpPluginState = Record<string, unknown>
+
 export interface HttpRequestContext<T = unknown> {
   method: HttpMethods;
   path: string;
   data?: unknown;
   config?: RequestConfig<T>;
+  state: HttpPluginState;
   url: string;
   request: RequestInit;
   headers: Headers;
@@ -329,6 +332,7 @@ export class HttpClient {
       path,
       data,
       config,
+      state: {},
       url: this.buildUrl(path, config?.params, config?.search),
       headers,
       request: {


### PR DESCRIPTION
## Summary
- add `headers` to `HttpResult<T>` so callers can access response metadata
- include response headers on success and parse/validation/response errors
- set `headers: null` for network/timeout errors where no HTTP response exists
- update README usage and plugin example to demonstrate `result.headers`

## Notes
- no runtime behavior changes besides exposing headers on result objects


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP response headers are now accessible in all API results
  * Introduced a plugin system with request and response hooks for custom request/response processing

* **Documentation**
  * Expanded README with comprehensive plugin documentation and practical usage examples including authentication, timing, and composition patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->